### PR TITLE
Add build scripts

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,203 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,47 @@
-# openjdk11-upstream-binaries
-Not to be confused with the official AdoptOpenJDK binaries [openjdk11-binaries](https://github.com/AdoptOpenJDK/openjdk11-reference-binaries).
+# OpenJDK Upstream Binaries (JDK 11u)
+
+Not to be confused with the official AdoptOpenJDK binaries [openjdk11-binaries](https://github.com/AdoptOpenJDK/openjdk11-binaries).
 
 _openjdk11-upstream-binaries_ are pure unaltered builds from the OpenJDK mercurial jdk11u code stream which have been built by Red Hat on behalf of the OpenJDK community jdk11u updates project.
+
+## Build Scripts
+
+This repository also contains [build scripts](install-rhel6-deps-build-openjdk11.sh) which were used to produce binaries released under this repository. See [usage](README.md#Usage) for more information.
+
+### Usage
+
+On your newly commissioned RHEL 6 machine, you can run these steps to produce a build:
+
+    $ wget -O openjdk11-upstream-binaries-master.tar.gz "https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/archive/master.tar.gz"
+    $ tar -xf openjdk11-upstream-binaries-master.tar.gz
+    $ cd openjdk11-upstream-binaries-master
+    $ bash install-rhel6-deps-build-openjdk11.sh
+
+This will produce a file in `/home/openjdk` called `openjdk-*-all-artefacts.tar.gz`,
+which is about 742 MB in size, containing:
+
+ * The JDK 11 build log
+ * The JDK 11 image without debuginfo
+ * The JKD 11 debuginfo files for the JDK 11 image (overlay)
+ * The JDK 11 image in slowdebug version
+ * The JDK 11 debuginfo files for the slowdebug version (overlay)
+ * The JDK 11 source tarball
+
+Example:
+
+    jdk11u/build/release/images/openjdk-11u-11.0.3+0-debuginfo.tar.gz
+    jdk11u/build/release/images/openjdk-11u-11.0.3+0.tar.gz
+    jdk11u/build/openjdk-11u-11.0.3+0-sources.tar.gz
+    jdk11u/build/slowdebug/images/openjdk-11u-11.0.3+0-slowdebug.tar.gz
+    jdk11u/build/slowdebug/images/openjdk-11u-11.0.3+0-slowdebug-debuginfo.tar.gz
+    jdk11u/overall-build.log
+
+### Only Build OpenJDK 11 (without Build Requirements)
+
+If you already have the build requirements for building OpenJDK 11 installed, you can
+use a simpler build script to build OpenJDK 11:
+
+    $ wget -O openjdk11-upstream-binaries-master.tar.gz "https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/archive/master.tar.gz"
+    $ tar -xf openjdk11-upstream-binaries-master.tar.gz
+    $ cd openjdk11-upstream-binaries-master
+    $ bash build-openjdk11.sh

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ which is about 742 MB in size, containing:
 
 Example:
 
-    jdk11u/build/release/images/openjdk-11u-11.0.3+0-debuginfo.tar.gz
-    jdk11u/build/release/images/openjdk-11u-11.0.3+0.tar.gz
-    jdk11u/build/openjdk-11u-11.0.3+0-sources.tar.gz
-    jdk11u/build/slowdebug/images/openjdk-11u-11.0.3+0-slowdebug.tar.gz
-    jdk11u/build/slowdebug/images/openjdk-11u-11.0.3+0-slowdebug-debuginfo.tar.gz
+    jdk11u/build/release/images/OpenJDK11U-x64_linux_11.0.3_4_ea-debuginfo.tar.gz
+    jdk11u/build/release/images/OpenJDK11U-x64_linux_11.0.3_4_ea.tar.gz
+    jdk11u/build/OpenJDK11U-sources_11.0.3_4_ea.tar.gz
+    jdk11u/build/slowdebug/images/OpenJDK11U-x64_linux_11.0.3_4_ea-slowdebug.tar.gz
+    jdk11u/build/slowdebug/images/OpenJDK11U-x64_linux_11.0.3_4_ea-slowdebug-debuginfo.tar.gz
     jdk11u/overall-build.log
 
 ### Only Build OpenJDK 11 (without Build Requirements)

--- a/build-openjdk10.sh
+++ b/build-openjdk10.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -e
+
+UPDATE="10.0.1"
+BUILD=10
+NAME="openjdk-10u-${UPDATE}-b${BUILD}"
+
+CLONE_URL=https://hg.openjdk.java.net/jdk-updates/jdk10u
+TAG=tip
+
+clone() {
+  url=$1
+  tag=$2
+  targetdir=$3
+  if [ -d $targetdir ]; then
+    echo "Target directory $targetdir already exists. Skipping clone"
+    return
+  fi
+  hg clone -u $tag $url $targetdir
+}
+
+build() {
+  rm -rf build
+
+  # Add patch to be able to build on EL 6
+  wget https://bugs.openjdk.java.net/secure/attachment/81677/JDK-8219879.jdk10.export.patch
+  patch -p1 < JDK-8219879.jdk10.export.patch
+  # Pragmas not allowed inside functions
+  wget https://bugs.openjdk.java.net/secure/attachment/81678/JDK-8220086.jdk10.export.patch
+  patch -p1 < JDK-8220086.jdk10.export.patch
+
+  bash make/autoconf/autogen.sh
+
+  # Note: Boot JDK 9 built on RHEL-6 with build-openjdk9.sh
+  # 
+  # $ cd /opt && sudo tar -xf openjdk9u-9.0.4-b12.tar.gz
+  for debug in release slowdebug; do
+    bash configure \
+       --with-boot-jdk="/opt/openjdk9u-9.0.4-b12" \
+       --with-debug-level="$debug" \
+       --with-conf-name="$debug" \
+       --enable-unlimited-crypto \
+       --with-version-build=$BUILD \
+       --with-version-pre="" \
+       --with-version-opt="" \
+       --with-native-debug-symbols=external \
+       --with-cacerts-file=/etc/pki/java/cacerts \
+       --disable-warnings-as-errors
+    target="bootcycle-images"
+    if [ "${debug}_" == "slowdebug_" ]; then
+      target="images"
+    fi
+    make LOG_LEVEL=debug CONF=$debug $target
+    # Package it up
+    pushd build/$debug/images
+      if [ "${debug}_" == "slowdebug_" ]; then
+	NAME="$NAME-$debug"
+      fi
+      mv jdk $NAME    
+      tar -c -f $NAME.tar $NAME --exclude='**.debuginfo'
+      gzip $NAME.tar
+      tar -c -f $NAME-debuginfo.tar $(find ${NAME}/ -name \*.debuginfo)
+      gzip $NAME-debuginfo.tar
+      mv $NAME jdk
+    popd
+  done
+
+  find $(pwd)/build -name \*.tar.gz
+}
+
+clone $CLONE_URL $TAG jdk10u
+pushd jdk10u
+  build
+popd

--- a/build-openjdk11.sh
+++ b/build-openjdk11.sh
@@ -4,13 +4,17 @@ set -e
 UPDATE="11.0.3"
 BUILD=4
 NAME="openjdk-11u-${UPDATE}+${BUILD}"
-NAME_SUFFIX="ea-linux-x86_64"
-SOURCE_NAME="${NAME}-sources"
+TARBALL_BASE_NAME="OpenJDK11U"
+EA_SUFFIX="_ea"
+PLATFORM="x64_linux"
+TARBALL_VERSION="${UPDATE}_${BUILD}${EA_SUFFIX}"
+TARBALL_NAME="${TARBALL_BASE_NAME}-${PLATFORM}_${TARBALL_VERSION}"
+SOURCE_NAME="${TARBALL_BASE_NAME}-sources_${TARBALL_VERSION}"
 # Release string for the vendor. Use the GA date.
 VENDOR="18.9"
 
 CLONE_URL=https://hg.openjdk.java.net/jdk-updates/jdk11u
-TAG="jdk-11.0.3+4"
+TAG="jdk-${UPDATE}+${BUILD}"
 
 clone() {
   url=$1
@@ -32,7 +36,7 @@ build() {
   
   # Create a source tarball archive corresponding to the
   # binary build
-  tar -c -z -f ../$SOURCE_NAME.tar.gz --exclude-vcs --exclude='**.patch*' --exclude='overall-build.log' .
+  tar -c -z -f ../${SOURCE_NAME}.tar.gz --exclude-vcs --exclude='**.patch*' --exclude='overall-build.log' .
   # NOTE: Boot JDK built with build-openjdk10.sh
   for debug in release slowdebug; do
     bash configure \
@@ -55,16 +59,17 @@ build() {
     pushd build/$debug/images
       if [ "${debug}_" == "slowdebug_" ]; then
 	NAME="$NAME-$debug"
+	TARBALL_NAME="$TARBALL_NAME-$debug"
       fi
       mv jdk $NAME    
-      tar -c -f $NAME-$NAME_SUFFIX.tar $NAME --exclude='**.debuginfo'
-      gzip $NAME-$NAME_SUFFIX.tar
-      tar -c -f $NAME-$NAME_SUFFIX-debuginfo.tar $(find ${NAME}/ -name \*.debuginfo)
-      gzip $NAME-$NAME_SUFFIX-debuginfo.tar
+      tar -c -f ${TARBALL_NAME}.tar $NAME --exclude='**.debuginfo'
+      gzip ${TARBALL_NAME}.tar
+      tar -c -f ${TARBALL_NAME}-debuginfo.tar $(find ${NAME}/ -name \*.debuginfo)
+      gzip ${TARBALL_NAME}-debuginfo.tar
       mv $NAME jdk
     popd
   done
-  mv ../$SOURCE_NAME.tar.gz build/
+  mv ../${SOURCE_NAME}.tar.gz build/
   find $(pwd)/build -name \*.tar.gz
 }
 

--- a/build-openjdk11.sh
+++ b/build-openjdk11.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -e
+
+UPDATE="11.0.3"
+BUILD=4
+NAME="openjdk-11u-${UPDATE}+${BUILD}"
+NAME_SUFFIX="ea-linux-x86_64"
+SOURCE_NAME="${NAME}-sources"
+# Release string for the vendor. Use the GA date.
+VENDOR="18.9"
+
+CLONE_URL=https://hg.openjdk.java.net/jdk-updates/jdk11u
+TAG="jdk-11.0.3+4"
+
+clone() {
+  url=$1
+  tag=$2
+  targetdir=$3
+  if [ -d $targetdir ]; then
+    echo "Target directory $targetdir already exists. Skipping clone"
+    return
+  fi
+  hg clone -u $tag $url $targetdir
+}
+
+build() {
+  rm -rf build
+
+  # Add patch to be able to build on EL 6
+  wget https://bugs.openjdk.java.net/secure/attachment/81704/JDK-8219879.jdk11.export.patch
+  patch -p1 < JDK-8219879.jdk11.export.patch
+  
+  # Create a source tarball archive corresponding to the
+  # binary build
+  tar -c -z -f ../$SOURCE_NAME.tar.gz --exclude-vcs --exclude='**.patch*' --exclude='overall-build.log' .
+  # NOTE: Boot JDK built with build-openjdk10.sh
+  for debug in release slowdebug; do
+    bash configure \
+       --with-boot-jdk="/opt/openjdk-10u10.0.1-b10/" \
+       --with-debug-level="$debug" \
+       --with-conf-name="$debug" \
+       --enable-unlimited-crypto \
+       --with-version-build=$BUILD \
+       --with-version-pre="" \
+       --with-version-opt="" \
+       --with-vendor-version-string="$VENDOR" \
+       --with-native-debug-symbols=external \
+       --disable-warnings-as-errors
+    target="bootcycle-images"
+    if [ "${debug}_" == "slowdebug_" ]; then
+      target="images"
+    fi
+    make LOG=debug CONF=$debug $target
+    # Package it up
+    pushd build/$debug/images
+      if [ "${debug}_" == "slowdebug_" ]; then
+	NAME="$NAME-$debug"
+      fi
+      mv jdk $NAME    
+      tar -c -f $NAME-$NAME_SUFFIX.tar $NAME --exclude='**.debuginfo'
+      gzip $NAME-$NAME_SUFFIX.tar
+      tar -c -f $NAME-$NAME_SUFFIX-debuginfo.tar $(find ${NAME}/ -name \*.debuginfo)
+      gzip $NAME-$NAME_SUFFIX-debuginfo.tar
+      mv $NAME jdk
+    popd
+  done
+  mv ../$SOURCE_NAME.tar.gz build/
+  find $(pwd)/build -name \*.tar.gz
+}
+
+clone $CLONE_URL $TAG jdk11u
+pushd jdk11u
+  build
+popd

--- a/build-openjdk9.sh
+++ b/build-openjdk9.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e
+
+UPDATE="9.0.4"
+BUILD=12
+NAME="openjdk-9u${UPDATE}-b${BUILD}"
+
+CLONE_URL=https://hg.openjdk.java.net/jdk9-updates/jdk9u
+TAG=tip
+
+clone() {
+  url=$1
+  tag=$2
+  targetdir=$3
+  if [ -d $targetdir ]; then
+    echo "Target directory $targetdir already exists. Skipping clone"
+    return
+  fi
+  hg clone -u $tag $url $targetdir
+  pushd $targetdir
+    for i in corba hotspot jaxws jaxp jdk langtools nashorn; do
+      hg clone -u $tag $url/$i
+    done
+  popd
+}
+
+build() {
+  rm -rf build
+
+  # Add patch to be able to build on EL 6
+  wget https://bugs.openjdk.java.net/secure/attachment/81657/JDK-8219879.jdk9.export.patch
+  patch -p1 < JDK-8219879.jdk9.export.patch
+
+  bash common/autoconf/autogen.sh
+
+  for debug in release slowdebug; do
+    bash configure \
+       --with-boot-jdk="/usr/lib/jvm/java-1.8.0-openjdk.x86_64/" \
+       --with-debug-level="$debug" \
+       --with-conf-name="$debug" \
+       --enable-unlimited-crypto \
+       --with-version-build=$BUILD \
+       --with-version-pre="" \
+       --with-version-opt="" \
+       --with-native-debug-symbols=external \
+       --with-cacerts-file=/etc/pki/java/cacerts \
+    target="bootcycle-images"
+    if [ "${debug}_" == "slowdebug_" ]; then
+      target="images"
+    fi
+    make LOG_LEVEL=debug CONF=$debug $target
+    # Package it up
+    pushd build/$debug/images
+      if [ "${debug}_" == "slowdebug_" ]; then
+	NAME="$NAME-$debug"
+      fi
+      mv jdk $NAME    
+      tar -c -f $NAME.tar $NAME --exclude='**.debuginfo'
+      gzip $NAME.tar
+      tar -c -f $NAME-debuginfo.tar $(find ${NAME}/ -name \*.debuginfo)
+      gzip $NAME-debuginfo.tar
+      mv $NAME jdk
+    popd
+  done
+
+  find $(pwd)/build -name \*.tar.gz
+}
+
+clone $CLONE_URL $TAG jdk9u
+pushd jdk9u
+  build
+popd

--- a/install-rhel6-deps-build-openjdk11.sh
+++ b/install-rhel6-deps-build-openjdk11.sh
@@ -56,8 +56,12 @@ set -e
 UPDATE="11.0.3"
 BUILD=4
 NAME="openjdk-11u-\${UPDATE}+\${BUILD}"
-NAME_SUFFIX="ea-linux-x86_64"
-SOURCE_NAME="\${NAME}-sources"
+TARBALL_BASE_NAME="OpenJDK11U"
+EA_SUFFIX="_ea"
+PLATFORM="x64_linux"
+TARBALL_VERSION="\${UPDATE}_\${BUILD}\${EA_SUFFIX}"
+TARBALL_NAME="\${TARBALL_BASE_NAME}-\${PLATFORM}_\${TARBALL_VERSION}"
+SOURCE_NAME="\${TARBALL_BASE_NAME}-sources_\${TARBALL_VERSION}"
 # Release string for the vendor. Use the GA date.
 VENDOR="18.9"
 
@@ -84,7 +88,7 @@ build() {
 
   # Create a source tarball archive corresponding to the
   # binary build
-  tar -c -z -f ../\$SOURCE_NAME.tar.gz --exclude-vcs --exclude='**.patch*' --exclude='overall-build.log' .
+  tar -c -z -f ../\${SOURCE_NAME}.tar.gz --exclude-vcs --exclude='**.patch*' --exclude='overall-build.log' .
 
   for debug in release slowdebug; do
     bash configure \
@@ -107,16 +111,17 @@ build() {
     pushd build/\$debug/images
       if [ "\${debug}_" == "slowdebug_" ]; then
 	NAME="\$NAME-\$debug"
+	TARBALL_NAME="\$TARBALL_NAME-\$debug"
       fi
       mv jdk \$NAME    
-      tar -c -f \$NAME-\$NAME_SUFFIX.tar \$NAME --exclude='**.debuginfo'
-      gzip \$NAME-\$NAME_SUFFIX.tar
-      tar -c -f \$NAME-\$NAME_SUFFIX-debuginfo.tar \$(find \${NAME}/ -name \*.debuginfo)
-      gzip \$NAME-\$NAME_SUFFIX-debuginfo.tar
+      tar -c -f \${TARBALL_NAME}.tar \$NAME --exclude='**.debuginfo'
+      gzip \${TARBALL_NAME}.tar
+      tar -c -f \${TARBALL_NAME}-debuginfo.tar \$(find \${NAME}/ -name \*.debuginfo)
+      gzip \${TARBALL_NAME}-debuginfo.tar
       mv \$NAME jdk
     popd
   done
-  mv ../\$SOURCE_NAME.tar.gz build/
+  mv ../\${SOURCE_NAME}.tar.gz build/
 
   find \$(pwd)/build -name \*.tar.gz
 }

--- a/install-rhel6-deps-build-openjdk11.sh
+++ b/install-rhel6-deps-build-openjdk11.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+set -e
+
+BRS_FILE=openjdk_build_deps.txt
+BUILD_SCRIPT=build-openjdk11.sh
+
+cat > $BRS_FILE <<EOF
+autoconf
+automake
+alsa-lib-devel
+binutils
+cups-devel
+fontconfig
+freetype-devel
+giflib-devel
+gcc-c++
+gtk2-devel
+libjpeg-devel
+libpng-devel
+libxslt
+libX11-devel
+libXi-devel
+libXinerama-devel
+libXt-devel
+libXtst-devel
+pkgconfig
+xorg-x11-proto-devel
+zip
+unzip
+java-1.7.0-openjdk-devel
+openssl
+mercurial
+wget
+patch
+gzip
+tar
+EOF
+
+# Download and install boot JDK
+#
+# Originally boot-strapped with build-openjdk9.sh and build-openjdk10.sh
+# For simplicity download a JDK 10 from AdoptOpenJDK
+pushd /opt
+wget "https://github.com/AdoptOpenJDK/openjdk10-releases/releases/download/jdk-10.0.2%2B13/OpenJDK10_x64_Linux_jdk-10.0.2%2B13.tar.gz"
+tar -xf OpenJDK10_x64_Linux_jdk-10.0.2+13.tar.gz
+/opt/jdk-10.0.2+13/bin/java -version
+popd
+
+yum -y install $(echo $(cat $BRS_FILE))
+useradd openjdk
+
+cat > $BUILD_SCRIPT <<EOF
+#!/bin/bash
+set -e
+
+UPDATE="11.0.3"
+BUILD=4
+NAME="openjdk-11u-\${UPDATE}+\${BUILD}"
+NAME_SUFFIX="ea-linux-x86_64"
+SOURCE_NAME="\${NAME}-sources"
+# Release string for the vendor. Use the GA date.
+VENDOR="18.9"
+
+CLONE_URL=https://hg.openjdk.java.net/jdk-updates/jdk11u
+TAG="jdk-11.0.3+4"
+
+clone() {
+  url=\$1
+  tag=\$2
+  targetdir=\$3
+  if [ -d \$targetdir ]; then
+    echo "Target directory \$targetdir already exists. Skipping clone"
+    return
+  fi
+  hg clone -u \$tag \$url \$targetdir
+}
+
+build() {
+  rm -rf build
+
+  # Add patch to be able to build on EL 6
+  wget https://bugs.openjdk.java.net/secure/attachment/81704/JDK-8219879.jdk11.export.patch
+  patch -p1 < JDK-8219879.jdk11.export.patch
+
+  # Create a source tarball archive corresponding to the
+  # binary build
+  tar -c -z -f ../\$SOURCE_NAME.tar.gz --exclude-vcs --exclude='**.patch*' --exclude='overall-build.log' .
+
+  for debug in release slowdebug; do
+    bash configure \
+       --with-boot-jdk="/opt/jdk-10.0.2+13/" \
+       --with-debug-level="\$debug" \
+       --with-conf-name="\$debug" \
+       --enable-unlimited-crypto \
+       --with-version-build=\$BUILD \
+       --with-version-pre="" \
+       --with-version-opt="" \
+       --with-vendor-version-string="\$VENDOR" \
+       --with-native-debug-symbols=external \
+       --disable-warnings-as-errors
+    target="bootcycle-images"
+    if [ "\${debug}_" == "slowdebug_" ]; then
+      target="images"
+    fi
+    make LOG=debug CONF=\$debug \$target
+    # Package it up
+    pushd build/\$debug/images
+      if [ "\${debug}_" == "slowdebug_" ]; then
+	NAME="\$NAME-\$debug"
+      fi
+      mv jdk \$NAME    
+      tar -c -f \$NAME-\$NAME_SUFFIX.tar \$NAME --exclude='**.debuginfo'
+      gzip \$NAME-\$NAME_SUFFIX.tar
+      tar -c -f \$NAME-\$NAME_SUFFIX-debuginfo.tar \$(find \${NAME}/ -name \*.debuginfo)
+      gzip \$NAME-\$NAME_SUFFIX-debuginfo.tar
+      mv \$NAME jdk
+    popd
+  done
+  mv ../\$SOURCE_NAME.tar.gz build/
+
+  find \$(pwd)/build -name \*.tar.gz
+}
+
+clone \$CLONE_URL \$TAG jdk11u
+pushd jdk11u
+  build 2>&1 | tee overall-build.log
+popd
+ALL_ARTEFACTS="\$NAME-all-artefacts.tar"
+tar -c -f \$ALL_ARTEFACTS \$(echo \$(find jdk11u/build -name \*.tar.gz) jdk11u/overall-build.log)
+gzip \$ALL_ARTEFACTS
+ls -lh \$(pwd)/*.tar.gz
+EOF
+
+cp $BUILD_SCRIPT /home/openjdk
+chown -R openjdk /home/openjdk
+
+# Drop privs and perform build
+su -c "bash $BUILD_SCRIPT" - openjdk

--- a/install-rhel6-deps-build-openjdk11.sh
+++ b/install-rhel6-deps-build-openjdk11.sh
@@ -66,7 +66,7 @@ SOURCE_NAME="\${TARBALL_BASE_NAME}-sources_\${TARBALL_VERSION}"
 VENDOR="18.9"
 
 CLONE_URL=https://hg.openjdk.java.net/jdk-updates/jdk11u
-TAG="jdk-11.0.3+4"
+TAG="jdk-\${UPDATE}+\${BUILD}"
 
 clone() {
   url=\$1


### PR DESCRIPTION
Red Hat is an Open Source company and we strive to be transparent. In this spirit, we'd like to share the build scripts for upstream JDK 11 builds released via this repository. This is to:

1. Prevent any speculation as to what those builds are and how they were produced
2. Show that those builds are verbatim upstream builds with as little modifications as possible

Thoughts?