### PR TITLE
Changes to produce additional release artefact with Shenandoah enabled

### DIFF
--- a/install-rhel-deps-build-openjdk11.sh
+++ b/install-rhel-deps-build-openjdk11.sh
@@ -140,7 +140,10 @@ TARBALL_VERSION="\${UPDATE}_\${BUILD}\${EA_SUFFIX}"
 PLATFORM_VERSION="\${PLATFORM}_\${TARBALL_VERSION}"
 TARBALL_NAME="\${TARBALL_BASE_NAME}-jdk_\${PLATFORM_VERSION}"
 TARBALL_NAME_JRE="\${TARBALL_BASE_NAME}-jre_\${PLATFORM_VERSION}"
+TARBALL_NAME_SHENANDOAH="\${TARBALL_BASE_NAME}-jdk-shenandoah_\${PLATFORM_VERSION}"
+TARBALL_NAME_SHENANDOAH_JRE="\${TARBALL_BASE_NAME}-jre-shenandoah_\${PLATFORM_VERSION}"
 TARBALL_NAME_TEST_IMAGE="\${TARBALL_BASE_NAME}-testimage_\${PLATFORM_VERSION}"
+TARBALL_NAME_SHENANDOAH_TEST_IMAGE="\${TARBALL_BASE_NAME}-testimage-shenandoah_\${PLATFORM_VERSION}"
 TARBALL_NAME_STATIC_LIBS="\${TARBALL_BASE_NAME}-static-libs_\${PLATFORM_VERSION}"
 SOURCE_NAME="\${TARBALL_BASE_NAME}-sources_\${TARBALL_VERSION}"
 # Release string for the vendor. Use the GA date.
@@ -184,10 +187,18 @@ build() {
     VERSION_PRE="ea"
   fi
 
-  for debug in release slowdebug; do
+  for debug in release shenandoah slowdebug; do
+    if [ "\$debug" == "shenandoah" ]; then
+       flag="--with-jvm-features=shenandoahgc"
+       dbg_level="release"
+    else
+       flag=""
+       dbg_level="\$debug"
+    fi
     bash configure \
        --with-boot-jdk="$BOOT_JDK" \
-       --with-debug-level="\$debug" \
+       "\$flag" \
+       --with-debug-level="\$dbg_level" \
        --with-conf-name="\$debug" \
        --enable-unlimited-crypto \
        --with-version-build=\$BUILD \
@@ -201,30 +212,38 @@ build() {
       targets="images"
     fi
     make LOG=debug CONF=\$debug \$targets
+    archive_name="\$TARBALL_NAME"
+    jre_archive_name="\$TARBALL_NAME_JRE"
+    testimage_archive_name="\$TARBALL_NAME_TEST_IMAGE"
+    if [ "\${debug}_" == "shenandoah_" ]; then
+      archive_name="\$TARBALL_NAME_SHENANDOAH"
+      jre_archive_name="\$TARBALL_NAME_SHENANDOAH_JRE"
+      testimage_archive_name="\$TARBALL_NAME_SHENANDOAH_TEST_IMAGE"
+    fi
     # Package it up
     pushd build/\$debug/images
       if [ "\${debug}_" == "slowdebug_" ]; then
 	NAME="\$NAME-\$debug"
-	TARBALL_NAME="\$TARBALL_NAME-\$debug"
+	archive_name="\$archive_name-\$debug"
       fi
       mv jdk \$NAME    
-      tar -c -f \${TARBALL_NAME}.tar --exclude='**.debuginfo' \$NAME
-      gzip \${TARBALL_NAME}.tar
-      tar -c -f \${TARBALL_NAME}-debuginfo.tar \$(find \${NAME}/ -name \*.debuginfo)
-      gzip \${TARBALL_NAME}-debuginfo.tar
+      tar -c -f \${archive_name}.tar --exclude='**.debuginfo' \$NAME
+      gzip \${archive_name}.tar
+      tar -c -f \${archive_name}-debuginfo.tar \$(find \${NAME}/ -name \*.debuginfo)
+      gzip \${archive_name}-debuginfo.tar
       mv \$NAME jdk
       # JRE package produced via legacy-images (release only)
-      if [ "\${debug}_" == "release_" ]; then
+      if [ "\${debug}_" == "release_" ] || [ "\${debug}_" == "shenandoah_" ]; then
         mv jre \$JRE_NAME
-        tar -c -f \${TARBALL_NAME_JRE}.tar --exclude='**.debuginfo' \$JRE_NAME
-        gzip \${TARBALL_NAME_JRE}.tar
-        tar -c -f \${TARBALL_NAME_JRE}-debuginfo.tar \$(find \${JRE_NAME}/ -name \*.debuginfo)
-        gzip \${TARBALL_NAME_JRE}-debuginfo.tar
+        tar -c -f \${jre_archive_name}.tar --exclude='**.debuginfo' \$JRE_NAME
+        gzip \${jre_archive_name}.tar
+        tar -c -f \${jre_archive_name}-debuginfo.tar \$(find \${JRE_NAME}/ -name \*.debuginfo)
+        gzip \${jre_archive_name}-debuginfo.tar
         mv \$JRE_NAME jre
         # Test image (release-only: needed for after-the-fact testing with native libs)
         mv "test" \$TEST_IMAGE_NAME
-        tar -c -f \${TARBALL_NAME_TEST_IMAGE}.tar \$TEST_IMAGE_NAME
-        gzip \${TARBALL_NAME_TEST_IMAGE}.tar
+        tar -c -f \${testimage_archive_name}.tar \$TEST_IMAGE_NAME
+        gzip \${testimage_archive_name}.tar
         mv \$TEST_IMAGE_NAME "test"
         # Static libraries (release-only: needed for building graal vm with native image)
         # Tar as overlay


### PR DESCRIPTION
@jerboaa Could you please review the changes and let me know the comments?

Veified the build and looks it is as expected.

1.
**Config without: --with-jvm-features=shenandoah
**Build artefact dir is 'release'
./java -XX:+UseShenandoahGC -version
Unrecognized VM option 'UseShenandoahGC'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.

2.
**Config with --with-jvm-features=shenandoah
**Build artefact dir is 'shenandoah'
./java -XX:+UseShenandoahGC -version
openjdk version "11.0.9-ea" 2020-10-20
OpenJDK Runtime Environment 18.9 (build 11.0.9-ea+10)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.9-ea+10, mixed mode)

3.
ls 
OpenJDK11U-sources_11.0.9_10_ea.tar.gz  release  shenandoah  slowdebug

Thank you!