### PR TITLE
Fix to remove empty static-libs folder in the tarball

### DIFF
--- a/build-openjdk11.sh
+++ b/build-openjdk11.sh
@@ -167,7 +167,7 @@ build() {
         mv $TEST_IMAGE_NAME "test"
         # Static libraries (release-only: needed for building graal vm with native image)
         # Tar as overlay
-        tar --transform "s|^static-libs/lib/*|${NAME}/lib/static/linux-${STATICLIBS_ARCH}/glibc/|" -c -f ${TARBALL_NAME_STATIC_LIBS}.tar "static-libs"
+        tar --transform "s|^static-libs/*|${NAME}/lib/static/linux-${STATICLIBS_ARCH}/glibc/|" -c -f ${TARBALL_NAME_STATIC_LIBS}.tar "static-libs"
         gzip ${TARBALL_NAME_STATIC_LIBS}.tar
       fi
     popd

--- a/install-rhel-deps-build-openjdk11.sh
+++ b/install-rhel-deps-build-openjdk11.sh
@@ -247,7 +247,7 @@ build() {
         mv \$TEST_IMAGE_NAME "test"
         # Static libraries (release-only: needed for building graal vm with native image)
         # Tar as overlay
-        tar --transform "s|^static-libs/lib/*|\${NAME}/lib/static/linux-\${STATICLIBS_ARCH}/glibc/|" -c -f \${TARBALL_NAME_STATIC_LIBS}.tar "static-libs"
+        tar --transform "s|^static-libs/*|\${NAME}/lib/static/linux-\${STATICLIBS_ARCH}/glibc/|" -c -f \${TARBALL_NAME_STATIC_LIBS}.tar "static-libs"
         gzip \${TARBALL_NAME_STATIC_LIBS}.tar
       fi
     popd


### PR DESCRIPTION
Could you please review the patch?

I have verified the build and is as below with this patch:

#tar -tf OpenJDK11U-static-libs_aarch64_linux_11.0.10_8_ea.tar.gz | grep static-libs
#tar -tf OpenJDK11U-static-libs_aarch64_linux_11.0.10_8_ea.tar.gz
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libfdlibm.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libjava.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libjimage.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libjli.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libjsig.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libnet.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libnio.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libverify.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libzip.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libawt.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libawt_headless.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libawt_xawt.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libfontmanager.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libharfbuzz.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libjavajpeg.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libjawt.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libjsound.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/liblcms.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libmlib_image.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libsplashscreen.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libinstrument.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libmanagement.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libprefs.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/librmi.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libj2gss.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libj2pcsc.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libattach.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libj2pkcs11.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libsunec.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libsaproc.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libdt_socket.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libjdwp.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libmanagement_ext.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libmanagement_agent.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libextnet.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libunpack.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libsctp.a
openjdk-11.0.10_8/lib/static/linux-aarch64/glibc/lib/libjaas.a