### PR TITLE
Fix to restore the change in static_libs path

### DIFF
--- a/build-openjdk11.sh
+++ b/build-openjdk11.sh
@@ -167,7 +167,7 @@ build() {
         mv $TEST_IMAGE_NAME "test"
         # Static libraries (release-only: needed for building graal vm with native image)
         # Tar as overlay
-        tar --transform "s|^static-libs/*|${NAME}/lib/static/linux-${STATICLIBS_ARCH}/glibc/|" -c -f ${TARBALL_NAME_STATIC_LIBS}.tar "static-libs"
+        tar --transform "s|^static-libs/lib/*|${NAME}/lib/static/linux-${STATICLIBS_ARCH}/glibc/|" -c -f ${TARBALL_NAME_STATIC_LIBS}.tar "static-libs/lib"
         gzip ${TARBALL_NAME_STATIC_LIBS}.tar
       fi
     popd

--- a/install-rhel-deps-build-openjdk11.sh
+++ b/install-rhel-deps-build-openjdk11.sh
@@ -247,7 +247,7 @@ build() {
         mv \$TEST_IMAGE_NAME "test"
         # Static libraries (release-only: needed for building graal vm with native image)
         # Tar as overlay
-        tar --transform "s|^static-libs/*|\${NAME}/lib/static/linux-\${STATICLIBS_ARCH}/glibc/|" -c -f \${TARBALL_NAME_STATIC_LIBS}.tar "static-libs"
+        tar --transform "s|^static-libs/lib/*|\${NAME}/lib/static/linux-\${STATICLIBS_ARCH}/glibc/|" -c -f \${TARBALL_NAME_STATIC_LIBS}.tar "static-libs/lib"
         gzip \${TARBALL_NAME_STATIC_LIBS}.tar
       fi
     popd


### PR DESCRIPTION
This is to address the issue #19 
First manually verified and then triggered a build with the patch in this PR

Before Fix:
$ ls -l openjdk-11.0.11_1.orig/lib/static/linux-aarch64/glibc/lib/
total 10748
-rw-rw-r--. 1 openjdk openjdk    9396 Feb  3 12:02 libattach.a
-rw-rw-r--. 1 openjdk openjdk 1048950 Feb  3 12:02 libawt.a
-rw-rw-r--. 1 openjdk openjdk   93840 Feb  3 12:02 libawt_headless.a
-rw-rw-r--. 1 openjdk openjdk 1126804 Feb  3 12:02 libawt_xawt.a
-rw-rw-r--. 1 openjdk openjdk   40794 Feb  3 12:02 libdt_socket.a
-rw-rw-r--. 1 openjdk openjdk   10344 Feb  3 12:02 libextnet.a
-rw-rw-r--. 1 openjdk openjdk  132306 Feb  3 12:02 libfdlibm.a
-rw-rw-r--. 1 openjdk openjdk   96884 Feb  3 12:02 libfontmanager.a
-rw-rw-r--. 1 openjdk openjdk 2404838 Feb  3 12:02 libharfbuzz.a
-rw-rw-r--. 1 openjdk openjdk  118962 Feb  3 12:02 libinstrument.a
-rw-rw-r--. 1 openjdk openjdk   97086 Feb  3 12:02 libj2gss.a
-rw-rw-r--. 1 openjdk openjdk   21278 Feb  3 12:02 libj2pcsc.a
-rw-rw-r--. 1 openjdk openjdk  184998 Feb  3 12:02 libj2pkcs11.a
-rw-rw-r--. 1 openjdk openjdk    4086 Feb  3 12:02 libjaas.a
-rw-rw-r--. 1 openjdk openjdk  361752 Feb  3 12:02 libjava.a
-rw-rw-r--. 1 openjdk openjdk  382734 Feb  3 12:02 libjavajpeg.a
-rw-rw-r--. 1 openjdk openjdk    3080 Feb  3 12:02 libjawt.a
-rw-rw-r--. 1 openjdk openjdk  856974 Feb  3 12:02 libjdwp.a
-rw-rw-r--. 1 openjdk openjdk   68636 Feb  3 12:02 libjimage.a
-rw-rw-r--. 1 openjdk openjdk  156990 Feb  3 12:02 libjli.a
-rw-rw-r--. 1 openjdk openjdk   11602 Feb  3 12:02 libjsig.a
-rw-rw-r--. 1 openjdk openjdk  148822 Feb  3 12:02 libjsound.a
-rw-rw-r--. 1 openjdk openjdk  883788 Feb  3 12:02 liblcms.a
-rw-rw-r--. 1 openjdk openjdk   52498 Feb  3 12:02 libmanagement.a
-rw-rw-r--. 1 openjdk openjdk    3256 Feb  3 12:02 libmanagement_agent.a
-rw-rw-r--. 1 openjdk openjdk   55480 Feb  3 12:02 libmanagement_ext.a
-rw-rw-r--. 1 openjdk openjdk  520888 Feb  3 12:02 libmlib_image.a
-rw-rw-r--. 1 openjdk openjdk  258278 Feb  3 12:02 libnet.a
-rw-rw-r--. 1 openjdk openjdk  179880 Feb  3 12:02 libnio.a
-rw-rw-r--. 1 openjdk openjdk    4360 Feb  3 12:02 libprefs.a
-rw-rw-r--. 1 openjdk openjdk    1770 Feb  3 12:02 librmi.a
-rw-rw-r--. 1 openjdk openjdk   96168 Feb  3 12:02 libsaproc.a
-rw-rw-r--. 1 openjdk openjdk   44724 Feb  3 12:02 libsctp.a
-rw-rw-r--. 1 openjdk openjdk  716440 Feb  3 12:02 libsplashscreen.a
-rw-rw-r--. 1 openjdk openjdk  403208 Feb  3 12:02 libsunec.a
-rw-rw-r--. 1 openjdk openjdk  194762 Feb  3 12:02 libunpack.a
-rw-rw-r--. 1 openjdk openjdk   76012 Feb  3 12:02 libverify.a
-rw-rw-r--. 1 openjdk openjdk   56620 Feb  3 12:02 libzip.a

After fix:
$ ls -l openjdk-11.0.11_1/lib/static/linux-amd64/glibc
total 10748
-rw-rw-r--. 1 openjdk openjdk    9396 Feb  3 12:02 libattach.a
-rw-rw-r--. 1 openjdk openjdk 1048950 Feb  3 12:02 libawt.a
-rw-rw-r--. 1 openjdk openjdk   93840 Feb  3 12:02 libawt_headless.a
-rw-rw-r--. 1 openjdk openjdk 1126804 Feb  3 12:02 libawt_xawt.a
-rw-rw-r--. 1 openjdk openjdk   40794 Feb  3 12:02 libdt_socket.a
-rw-rw-r--. 1 openjdk openjdk   10344 Feb  3 12:02 libextnet.a
-rw-rw-r--. 1 openjdk openjdk  132306 Feb  3 12:02 libfdlibm.a
-rw-rw-r--. 1 openjdk openjdk   96884 Feb  3 12:02 libfontmanager.a
-rw-rw-r--. 1 openjdk openjdk 2404838 Feb  3 12:02 libharfbuzz.a
-rw-rw-r--. 1 openjdk openjdk  118962 Feb  3 12:02 libinstrument.a
-rw-rw-r--. 1 openjdk openjdk   97086 Feb  3 12:02 libj2gss.a
-rw-rw-r--. 1 openjdk openjdk   21278 Feb  3 12:02 libj2pcsc.a
-rw-rw-r--. 1 openjdk openjdk  184998 Feb  3 12:02 libj2pkcs11.a
-rw-rw-r--. 1 openjdk openjdk    4086 Feb  3 12:02 libjaas.a
-rw-rw-r--. 1 openjdk openjdk  361752 Feb  3 12:02 libjava.a
-rw-rw-r--. 1 openjdk openjdk  382734 Feb  3 12:02 libjavajpeg.a
-rw-rw-r--. 1 openjdk openjdk    3080 Feb  3 12:02 libjawt.a
-rw-rw-r--. 1 openjdk openjdk  856974 Feb  3 12:02 libjdwp.a
-rw-rw-r--. 1 openjdk openjdk   68636 Feb  3 12:02 libjimage.a
-rw-rw-r--. 1 openjdk openjdk  156990 Feb  3 12:02 libjli.a
-rw-rw-r--. 1 openjdk openjdk   11602 Feb  3 12:02 libjsig.a
-rw-rw-r--. 1 openjdk openjdk  148822 Feb  3 12:02 libjsound.a
-rw-rw-r--. 1 openjdk openjdk  883788 Feb  3 12:02 liblcms.a
-rw-rw-r--. 1 openjdk openjdk   52498 Feb  3 12:02 libmanagement.a
-rw-rw-r--. 1 openjdk openjdk    3256 Feb  3 12:02 libmanagement_agent.a
-rw-rw-r--. 1 openjdk openjdk   55480 Feb  3 12:02 libmanagement_ext.a
-rw-rw-r--. 1 openjdk openjdk  520888 Feb  3 12:02 libmlib_image.a
-rw-rw-r--. 1 openjdk openjdk  258278 Feb  3 12:02 libnet.a
-rw-rw-r--. 1 openjdk openjdk  179880 Feb  3 12:02 libnio.a
-rw-rw-r--. 1 openjdk openjdk    4360 Feb  3 12:02 libprefs.a
-rw-rw-r--. 1 openjdk openjdk    1770 Feb  3 12:02 librmi.a
-rw-rw-r--. 1 openjdk openjdk   96168 Feb  3 12:02 libsaproc.a
-rw-rw-r--. 1 openjdk openjdk   44724 Feb  3 12:02 libsctp.a
-rw-rw-r--. 1 openjdk openjdk  716440 Feb  3 12:02 libsplashscreen.a
-rw-rw-r--. 1 openjdk openjdk  403208 Feb  3 12:02 libsunec.a
-rw-rw-r--. 1 openjdk openjdk  194762 Feb  3 12:02 libunpack.a
-rw-rw-r--. 1 openjdk openjdk   76012 Feb  3 12:02 libverify.a
-rw-rw-r--. 1 openjdk openjdk   56620 Feb  3 12:02 libzip.a

So the patch is now as expected lib/static/linux-aarch64/glibc/lib/ to lib/static/linux-aarch64/glibc/ as reported in #19 

Once the build complete I will update here.