### PR TITLE
Changes to meet the harfbuzz requirement of gcc>=5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This repository also contains [build scripts](install-rhel6-deps-build-openjdk11
 
 ### Usage
 
+These build scripts require a compiler which supports the C++11 standard for the in-tree harfbuzz library. In order to get access to such a compiler on older systems it is recommended to subscribe the build host to the Red Hat Software Collections channel using subscription-manager. More details on how to do that here:
+https://access.redhat.com/documentation/en-us/red_hat_software_collections/1/html/1.2_release_notes/chap-installation
+
 On your newly commissioned RHEL machine, you can run these steps to produce a build:
 
     $ wget -O openjdk11-upstream-binaries-master.tar.gz "https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/archive/master.tar.gz"

--- a/build-openjdk11.sh
+++ b/build-openjdk11.sh
@@ -114,7 +114,7 @@ build() {
        flag=""
        dbg_level="$debug"
     fi
-    bash configure \
+    scl enable devtoolset-8 -- bash configure \
        --with-boot-jdk="/opt/openjdk-11.0.4+11/" \
        "\$flag" \
        --with-debug-level="$dbg_level" \
@@ -125,12 +125,12 @@ build() {
        --with-version-opt="" \
        --with-vendor-version-string="$VENDOR" \
        --with-native-debug-symbols=external \
-       --disable-warnings-as-errors
+       --disable-warnings-as-errors"
     targets="bootcycle-images legacy-images test-image static-libs-image"
     if [ "${debug}_" == "slowdebug_" ]; then
       targets="images"
     fi
-    make LOG=debug CONF=$debug $targets
+    scl enable devtoolset-8 -- make LOG=debug CONF=$debug $targets
     archive_name="$TARBALL_NAME"
     jre_archive_name="$TARBALL_NAME_JRE"
     testimage_archive_name="$TARBALL_NAME_TEST_IMAGE"

--- a/install-rhel-deps-build-openjdk11.sh
+++ b/install-rhel-deps-build-openjdk11.sh
@@ -55,8 +55,9 @@ binutils
 cups-devel
 fontconfig
 freetype-devel
+devtoolset-8
 giflib-devel
-gcc-c++
+devtoolset-8-gcc-c++
 gtk2-devel
 libjpeg-devel
 libpng-devel
@@ -198,7 +199,7 @@ build() {
        flag=""
        dbg_level="\$debug"
     fi
-    bash configure \
+    scl enable devtoolset-8 -- bash configure \
        --with-boot-jdk="$BOOT_JDK" \
        "\$flag" \
        --with-debug-level="\$dbg_level" \
@@ -214,7 +215,7 @@ build() {
     if [ "\${debug}_" == "slowdebug_" ]; then
       targets="images"
     fi
-    make LOG=debug CONF=\$debug \$targets
+    scl enable devtoolset-8 -- make LOG=debug CONF=\$debug \$targets
     archive_name="\$TARBALL_NAME"
     jre_archive_name="\$TARBALL_NAME_JRE"
     testimage_archive_name="\$TARBALL_NAME_TEST_IMAGE"


### PR DESCRIPTION
Could you please review the changes?

Verified the build:

[root@hpe-dl380pgen8-02-vm-2 openjdk11-upstream-binaries]# /home/openjdk/jdk11u/build/release/images/jdk/bin/java -Xinternalversion -version
OpenJDK 64-Bit Server VM (11.0.14+9) for linux-amd64 JRE (11.0.14+9), built on Feb  4 2022 02:28:19 by "openjdk" with gcc 8.3.1 20190311 (Red Hat 8.3.1-3)

[root@hpe-apollo-cn99xx-15-vm-27 openjdk11-upstream-binaries]# /home/openjdk/jdk11u/build/release/images/jdk/bin/java -Xinternalversion -version
OpenJDK 64-Bit Server VM (11.0.14+9) for linux-aarch64 JRE (11.0.14+9), built on Feb  3 2022 14:36:30 by "openjdk" with gcc 8.3.1 20190311 (Red Hat 8.3.1-3)